### PR TITLE
Fix compile warnings with latest Xcode (4.6.1)

### DIFF
--- a/ZipArchive.m
+++ b/ZipArchive.m
@@ -103,7 +103,7 @@
 	time_t current;
 	time( &current );
 	
-	zip_fileinfo zipInfo = {0};
+	zip_fileinfo zipInfo = {{0}};
 	zipInfo.dosDate = (unsigned long) current;
 	
     NSError* error = nil;

--- a/minizip/mztools.c
+++ b/minizip/mztools.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include "zlib.h"
 #include "unzip.h"
+#include "mztools.h"
 
 #define READ_8(adr)  ((unsigned char)*(adr))
 #define READ_16(adr) ( READ_8(adr) | (READ_8(adr+1) << 8) )


### PR DESCRIPTION
This pull request silences two warnings.
