### PR TITLE
Lib need autorelease pool

### DIFF
--- a/ZipArchive.m
+++ b/ZipArchive.m
@@ -258,127 +258,129 @@
 	const char* password = [_password cStringUsingEncoding:NSASCIIStringEncoding];
 	
 	do{
-		if( [_password length]==0 )
-			ret = unzOpenCurrentFile( _unzFile );
-		else
-			ret = unzOpenCurrentFilePassword( _unzFile, password );
-		if( ret!=UNZ_OK )
-		{
-			[self OutputErrorMessage:@"Error occurs"];
-			success = NO;
-			break;
-		}
-		// reading data and write to file
-		int read ;
-		unz_file_info	fileInfo ={0};
-		ret = unzGetCurrentFileInfo(_unzFile, &fileInfo, NULL, 0, NULL, 0, NULL, 0);
-		if( ret!=UNZ_OK )
-		{
-			[self OutputErrorMessage:@"Error occurs while getting file info"];
-			success = NO;
-			unzCloseCurrentFile( _unzFile );
-			break;
-		}
-		char* filename = (char*) malloc( fileInfo.size_filename +1 );
-        unzGetCurrentFileInfo(_unzFile, &fileInfo, filename, fileInfo.size_filename + 1, NULL, 0, NULL, 0);
-		filename[fileInfo.size_filename] = '\0';
-		
-		// check if it contains directory
-		NSString * strPath = [NSString stringWithCString:filename encoding:NSASCIIStringEncoding];
-		BOOL isDirectory = NO;
-		if( filename[fileInfo.size_filename-1]=='/' || filename[fileInfo.size_filename-1]=='\\')
-			isDirectory = YES;
-		free( filename );
-		if( [strPath rangeOfCharacterFromSet:[NSCharacterSet characterSetWithCharactersInString:@"/\\"]].location!=NSNotFound )
-		{// contains a path
-			strPath = [strPath stringByReplacingOccurrencesOfString:@"\\" withString:@"/"];
-		}
-		NSString* fullPath = [path stringByAppendingPathComponent:strPath];
-		
-		if( isDirectory )
-			[fman createDirectoryAtPath:fullPath withIntermediateDirectories:YES attributes:nil error:nil];
-		else
-			[fman createDirectoryAtPath:[fullPath stringByDeletingLastPathComponent] withIntermediateDirectories:YES attributes:nil error:nil];
-        
-		FILE* fp = NULL;
-        do
-		{
-			read = unzReadCurrentFile(_unzFile, buffer, 4096);
-			if (read >= 0)
-			{
-                if (fp == NULL) {
-                    if( [fman fileExistsAtPath:fullPath] && !isDirectory && !overwrite )
-                    {
-                        if( ![self OverWrite:fullPath] )
+        @autoreleasepool {
+            if( [_password length]==0 )
+                ret = unzOpenCurrentFile( _unzFile );
+            else
+                ret = unzOpenCurrentFilePassword( _unzFile, password );
+            if( ret!=UNZ_OK )
+            {
+                [self OutputErrorMessage:@"Error occurs"];
+                success = NO;
+                break;
+            }
+            // reading data and write to file
+            int read ;
+            unz_file_info	fileInfo ={0};
+            ret = unzGetCurrentFileInfo(_unzFile, &fileInfo, NULL, 0, NULL, 0, NULL, 0);
+            if( ret!=UNZ_OK )
+            {
+                [self OutputErrorMessage:@"Error occurs while getting file info"];
+                success = NO;
+                unzCloseCurrentFile( _unzFile );
+                break;
+            }
+            char* filename = (char*) malloc( fileInfo.size_filename +1 );
+            unzGetCurrentFileInfo(_unzFile, &fileInfo, filename, fileInfo.size_filename + 1, NULL, 0, NULL, 0);
+            filename[fileInfo.size_filename] = '\0';
+            
+            // check if it contains directory
+            NSString * strPath = [NSString stringWithCString:filename encoding:NSASCIIStringEncoding];
+            BOOL isDirectory = NO;
+            if( filename[fileInfo.size_filename-1]=='/' || filename[fileInfo.size_filename-1]=='\\')
+                isDirectory = YES;
+            free( filename );
+            if( [strPath rangeOfCharacterFromSet:[NSCharacterSet characterSetWithCharactersInString:@"/\\"]].location!=NSNotFound )
+            {// contains a path
+                strPath = [strPath stringByReplacingOccurrencesOfString:@"\\" withString:@"/"];
+            }
+            NSString* fullPath = [path stringByAppendingPathComponent:strPath];
+            
+            if( isDirectory )
+                [fman createDirectoryAtPath:fullPath withIntermediateDirectories:YES attributes:nil error:nil];
+            else
+                [fman createDirectoryAtPath:[fullPath stringByDeletingLastPathComponent] withIntermediateDirectories:YES attributes:nil error:nil];
+            
+            FILE* fp = NULL;
+            do
+            {
+                read = unzReadCurrentFile(_unzFile, buffer, 4096);
+                if (read >= 0)
+                {
+                    if (fp == NULL) {
+                        if( [fman fileExistsAtPath:fullPath] && !isDirectory && !overwrite )
                         {
-                            // don't process any more of the file, but continue
+                            if( ![self OverWrite:fullPath] )
+                            {
+                                // don't process any more of the file, but continue
+                                break;
+                            }
+                        }
+                        fp = fopen( (const char*)[fullPath UTF8String], "wb");
+                        if (fp == NULL) {
+                            [self OutputErrorMessage:@"Failed to open output file for writing"];
                             break;
                         }
                     }
-                    fp = fopen( (const char*)[fullPath UTF8String], "wb");
-                    if (fp == NULL) {
-                        [self OutputErrorMessage:@"Failed to open output file for writing"];
-                        break;
-                    }
+                    fwrite(buffer, read, 1, fp );
                 }
-				fwrite(buffer, read, 1, fp );
-			}
-			else // if (read < 0)
-			{
-                ret = read; // result will be an error code
-                success = NO;
-				[self OutputErrorMessage:@"Failed to read zip file"];
-			}
-		} while (read > 0);
-        
-		if (fp)
-		{
-			fclose( fp );
+                else // if (read < 0)
+                {
+                    ret = read; // result will be an error code
+                    success = NO;
+                    [self OutputErrorMessage:@"Failed to read zip file"];
+                }
+            } while (read > 0);
             
-            // add the full path of this file to the output array
-            [(NSMutableArray*)_unzippedFiles addObject:fullPath];
-            
-			// set the orignal datetime property
-			if( fileInfo.dosDate!=0 )
-			{
-				NSDate* orgDate = [[NSDate alloc] 
-								   initWithTimeInterval:(NSTimeInterval)fileInfo.dosDate 
-								   sinceDate:[self Date1980] ];
-
-				NSDictionary* attr = [NSDictionary dictionaryWithObject:orgDate forKey:NSFileModificationDate]; //[[NSFileManager defaultManager] fileAttributesAtPath:fullPath traverseLink:YES];
-				if( attr )
-				{
-				//	[attr  setValue:orgDate forKey:NSFileCreationDate];
-					if( ![[NSFileManager defaultManager] setAttributes:attr ofItemAtPath:fullPath error:nil] )
-					{
-						// cann't set attributes 
-						NSLog(@"Failed to set attributes");
-					}
-					
-				}
-				[orgDate release];
-				orgDate = nil;
-			}
-			
-		}
-        
-        if (ret == UNZ_OK) {
-            ret = unzCloseCurrentFile( _unzFile );
-            if (ret != UNZ_OK) {
-                [self OutputErrorMessage:@"file was unzipped but failed crc check"];
-                success = NO;
+            if (fp)
+            {
+                fclose( fp );
+                
+                // add the full path of this file to the output array
+                [(NSMutableArray*)_unzippedFiles addObject:fullPath];
+                
+                // set the orignal datetime property
+                if( fileInfo.dosDate!=0 )
+                {
+                    NSDate* orgDate = [[NSDate alloc]
+                                       initWithTimeInterval:(NSTimeInterval)fileInfo.dosDate
+                                       sinceDate:[self Date1980] ];
+                    
+                    NSDictionary* attr = [NSDictionary dictionaryWithObject:orgDate forKey:NSFileModificationDate]; //[[NSFileManager defaultManager] fileAttributesAtPath:fullPath traverseLink:YES];
+                    if( attr )
+                    {
+                        //	[attr  setValue:orgDate forKey:NSFileCreationDate];
+                        if( ![[NSFileManager defaultManager] setAttributes:attr ofItemAtPath:fullPath error:nil] )
+                        {
+                            // cann't set attributes 
+                            NSLog(@"Failed to set attributes");
+                        }
+                        
+                    }
+                    [orgDate release];
+                    orgDate = nil;
+                }
+                
             }
-        }
-        
-        if (ret == UNZ_OK) {
-            ret = unzGoToNextFile( _unzFile );
-        }
-        
-        if (_progressBlock && _numFiles) {
-            index++;
-            int p = index*100/_numFiles;
-            progress = p;
-            _progressBlock(progress, index, _numFiles);
+            
+            if (ret == UNZ_OK) {
+                ret = unzCloseCurrentFile( _unzFile );
+                if (ret != UNZ_OK) {
+                    [self OutputErrorMessage:@"file was unzipped but failed crc check"];
+                    success = NO;
+                }
+            }
+            
+            if (ret == UNZ_OK) {
+                ret = unzGoToNextFile( _unzFile );
+            }
+            
+            if (_progressBlock && _numFiles) {
+                index++;
+                int p = index*100/_numFiles;
+                progress = p;
+                _progressBlock(progress, index, _numFiles);
+            }
         }
 	} while (ret==UNZ_OK && ret!=UNZ_END_OF_LIST_OF_FILE);
 	return success;


### PR DESCRIPTION
During development i`ve found that with large amount of archive to unzip (in loop) app memory start to accumulate some unzipped data, and release only after loop is gone.

So i run several times two simple tests.

Input:

Zip Archive, size 2.2 MB
Unzip times: 75

Without autorelease pool: http://cl.ly/image/1m0S1R1s0b0g
With autorelease pool: http://cl.ly/image/0y04212X1k2U

I propose to add my minor changes (or do it yourself).

My point: 

For apps working with large amount of files accumulating memory is evil, and easily results to crash old devices with memory warning.

Sorry, for my english.

Regards.
