### PR TITLE
updated several types for osx Compatibility

### DIFF
--- a/ZipArchive.h
+++ b/ZipArchive.h
@@ -17,7 +17,7 @@
  files processed (as an integer from 0 to 100), the number of files processed so far and the
  total number of files in the archive is called after each file is processed.
  */
-typedef void(^ZipArchiveProgressUpdateBlock)(int percentage, int filesProcessed, int numFiles);
+typedef void(^ZipArchiveProgressUpdateBlock)(int percentage, int filesProcessed, unsigned long numFiles);
 	
 /**
     @protocol
@@ -65,12 +65,12 @@ typedef void(^ZipArchiveProgressUpdateBlock)(int percentage, int filesProcessed,
 
 @interface ZipArchive : NSObject {
 @private
-	void*		_zipFile;
-	void*		_unzFile;
+	void*           _zipFile;
+	void*           _unzFile;
 	
-    int         _numFiles;
-	NSString*   _password;
-	id			_delegate;
+    unsigned long   _numFiles;
+	NSString*       _password;
+	id              _delegate;
     ZipArchiveProgressUpdateBlock _progressBlock;
     
     NSArray*    _unzippedFiles;
@@ -81,7 +81,7 @@ typedef void(^ZipArchiveProgressUpdateBlock)(int percentage, int filesProcessed,
 
 /** a delegate object conforming to ZipArchiveDelegate protocol */
 @property (nonatomic, retain) id<ZipArchiveDelegate> delegate;
-@property (nonatomic, readonly) int numFiles;
+@property (nonatomic, readonly) unsigned long numFiles;
 @property (nonatomic, copy) ZipArchiveProgressUpdateBlock progressBlock;
 
 /**

--- a/ZipArchive.m
+++ b/ZipArchive.m
@@ -144,7 +144,7 @@
 	{
 		data = [ NSData dataWithContentsOfFile:file];
 		uLong crcValue = crc32( 0L,NULL, 0L );
-		crcValue = crc32( crcValue, (const Bytef*)[data bytes], [data length] );
+		crcValue = crc32( crcValue, (const Bytef*)[data bytes], (unsigned int)[data length] );
 		ret = zipOpenNewFileInZip3( _zipFile,
 								  (const char*) [newname cStringUsingEncoding:self.stringEncoding],
 								  &zipInfo,
@@ -168,7 +168,7 @@
 	{
 		data = [ NSData dataWithContentsOfFile:file];
 	}
-	unsigned int dataLen = [data length];
+	unsigned int dataLen = (unsigned int)[data length];
 	ret = zipWriteInFileInZip( _zipFile, (const void*)[data bytes], dataLen);
 	if( ret!=Z_OK )
 	{


### PR DESCRIPTION
Hello:
I imported ZipArchive to my cocoa project, and Xcode 5 show me several warnings due to basic type issue. Then I fixed them and sending this PR. : D 
Best Regards
