### PR TITLE
Fix Xcode analyze warnings.

### DIFF
--- a/ZipArchive.m
+++ b/ZipArchive.m
@@ -444,7 +444,6 @@
 {
     NSMutableDictionary *fileDictionary = [NSMutableDictionary dictionary];
     
-    BOOL success = YES;
     int index = 0;
     int progress = -1;
     int ret = unzGoToFirstFile( _unzFile );
@@ -465,7 +464,6 @@
             if( ret!=UNZ_OK )
             {
                 [self OutputErrorMessage:@"Error occurs"];
-                success = NO;
                 break;
             }
             // reading data and write to file
@@ -475,7 +473,6 @@
             if( ret!=UNZ_OK )
             {
                 [self OutputErrorMessage:@"Error occurs while getting file info"];
-                success = NO;
                 unzCloseCurrentFile( _unzFile );
                 break;
             }
@@ -505,7 +502,6 @@
                 else // if (read < 0)
                 {
                     ret = read; // result will be an error code
-                    success = NO;
                     [self OutputErrorMessage:@"Failed to read zip file"];
                 }
             } while (read > 0);
@@ -521,7 +517,6 @@
                 ret = unzCloseCurrentFile( _unzFile );
                 if (ret != UNZ_OK) {
                     [self OutputErrorMessage:@"file was unzipped but failed crc check"];
-                    success = NO;
                 }
             }
             

--- a/minizip/unzip.c
+++ b/minizip/unzip.c
@@ -611,9 +611,13 @@ local unzFile unzOpenInternal (const void *path,
     us.z_filefunc.zseek32_file = NULL;
     us.z_filefunc.ztell32_file = NULL;
     if (pzlib_filefunc64_32_def==NULL)
-        fill_fopen64_filefunc(&us.z_filefunc.zfile_func64);
+    {
+         fill_fopen64_filefunc(&us.z_filefunc.zfile_func64);
+    }
     else
-        us.z_filefunc = *pzlib_filefunc64_32_def;
+    {
+         us.z_filefunc = *pzlib_filefunc64_32_def;
+    }
     us.is64bitOpenFunction = is64bitOpenFunction;
 
 
@@ -1109,6 +1113,8 @@ local int unz64local_GetCurrentFileInfoInternal (unzFile file,
     else
         lSeek+=file_info.size_file_comment;
 
+    // silence Xcode analyse warning: Value stored in 'lSeek' is never read
+    (void)lSeek;
 
     if ((err==UNZ_OK) && (pfile_info!=NULL))
         *pfile_info=file_info;
@@ -1539,8 +1545,11 @@ extern int ZEXPORT unzOpenCurrentFile3 (unzFile file, int* method,
         (s->cur_file_info.compression_method!=Z_BZIP2ED) &&
 /* #endif */
         (s->cur_file_info.compression_method!=Z_DEFLATED))
+    {
 
-        err=UNZ_BADZIPFILE;
+        TRYFREE(pfile_in_zip_read_info);
+        return UNZ_BADZIPFILE;
+    }
 
     pfile_in_zip_read_info->crc32_wait=s->cur_file_info.crc;
     pfile_in_zip_read_info->crc32=0;


### PR DESCRIPTION
For "Value stored to 'p' is never read", add a "(void)p;" statement
to silence the analyze warning. We could also just delete the
increment but that might cause a future bug if 'p' is used in new
code after this block.

Fixes #53
Fixes #43
