### PR TITLE
Fixing warnings generated by Xcode 6.3.1

### DIFF
--- a/ZipArchive.m
+++ b/ZipArchive.m
@@ -444,7 +444,7 @@
 {
     NSMutableDictionary *fileDictionary = [NSMutableDictionary dictionary];
     
-    BOOL success = YES;
+    //BOOL success = YES;
     int index = 0;
     int progress = -1;
     int ret = unzGoToFirstFile( _unzFile );
@@ -465,7 +465,7 @@
             if( ret!=UNZ_OK )
             {
                 [self OutputErrorMessage:@"Error occurs"];
-                success = NO;
+                //success = NO;
                 break;
             }
             // reading data and write to file
@@ -475,7 +475,7 @@
             if( ret!=UNZ_OK )
             {
                 [self OutputErrorMessage:@"Error occurs while getting file info"];
-                success = NO;
+                //success = NO;
                 unzCloseCurrentFile( _unzFile );
                 break;
             }
@@ -505,7 +505,7 @@
                 else // if (read < 0)
                 {
                     ret = read; // result will be an error code
-                    success = NO;
+                    //success = NO;
                     [self OutputErrorMessage:@"Failed to read zip file"];
                 }
             } while (read > 0);
@@ -521,7 +521,7 @@
                 ret = unzCloseCurrentFile( _unzFile );
                 if (ret != UNZ_OK) {
                     [self OutputErrorMessage:@"file was unzipped but failed crc check"];
-                    success = NO;
+                    //success = NO;
                 }
             }
             

--- a/minizip/crypt.h
+++ b/minizip/crypt.h
@@ -32,7 +32,7 @@
 /***********************************************************************
  * Return the next byte in the pseudo-random sequence
  */
-static int decrypt_byte(unsigned long* pkeys, const unsigned long* pcrc_32_tab)
+static int decrypt_byte(unsigned long* pkeys)
 {
     unsigned temp;  /* POTENTIAL BUG:  temp*(temp^1) may overflow in an
                      * unpredictable manner on 16-bit systems; not a problem
@@ -74,10 +74,10 @@ static void init_keys(const char* passwd,unsigned long* pkeys,const unsigned lon
 }
 
 #define zdecode(pkeys,pcrc_32_tab,c) \
-    (update_keys(pkeys,pcrc_32_tab,c ^= decrypt_byte(pkeys,pcrc_32_tab)))
+    (update_keys(pkeys,pcrc_32_tab,c ^= decrypt_byte(pkeys)))
 
 #define zencode(pkeys,pcrc_32_tab,c,t) \
-    (t=decrypt_byte(pkeys,pcrc_32_tab), update_keys(pkeys,pcrc_32_tab,c), t^(c))
+    (t=decrypt_byte(pkeys), update_keys(pkeys,pcrc_32_tab,c), t^(c))
 
 #ifdef INCLUDECRYPTINGCODE_IFCRYPTALLOWED
 

--- a/minizip/crypt.h
+++ b/minizip/crypt.h
@@ -114,7 +114,7 @@ static int crypthead(const char* passwd,      /* password string */
     init_keys(passwd, pkeys, pcrc_32_tab);
     for (n = 0; n < RAND_HEAD_LEN-2; n++)
     {
-        c = (rand() >> 7) & 0xff;
+        c = arc4random_uniform(0x100);
         header[n] = (unsigned char)zencode(pkeys, pcrc_32_tab, c, t);
     }
     /* Encrypt random header (last two bytes is high word of crc) */

--- a/minizip/ioapi.c
+++ b/minizip/ioapi.c
@@ -19,34 +19,34 @@
 voidpf call_zopen64 (const zlib_filefunc64_32_def* pfilefunc,const void*filename,int mode)
 {
     if (pfilefunc->zfile_func64.zopen64_file != NULL)
-        return (*(pfilefunc->zfile_func64.zopen64_file)) (pfilefunc->zfile_func64.opaque,filename,mode);
+        return (*(pfilefunc->zfile_func64.zopen64_file)) (filename,mode);
     else
     {
-        return (*(pfilefunc->zopen32_file))(pfilefunc->zfile_func64.opaque,(const char*)filename,mode);
+        return (*(pfilefunc->zopen32_file))((const char*)filename,mode);
     }
 }
 
 long call_zseek64 (const zlib_filefunc64_32_def* pfilefunc,voidpf filestream, ZPOS64_T offset, int origin)
 {
     if (pfilefunc->zfile_func64.zseek64_file != NULL)
-        return (*(pfilefunc->zfile_func64.zseek64_file)) (pfilefunc->zfile_func64.opaque,filestream,offset,origin);
+        return (*(pfilefunc->zfile_func64.zseek64_file)) (filestream,offset,origin);
     else
     {
         uLong offsetTruncated = (uLong)offset;
         if (offsetTruncated != offset)
             return -1;
         else
-            return (*(pfilefunc->zseek32_file))(pfilefunc->zfile_func64.opaque,filestream,offsetTruncated,origin);
+            return (*(pfilefunc->zseek32_file))(filestream,offsetTruncated,origin);
     }
 }
 
 ZPOS64_T call_ztell64 (const zlib_filefunc64_32_def* pfilefunc,voidpf filestream)
 {
     if (pfilefunc->zfile_func64.zseek64_file != NULL)
-        return (*(pfilefunc->zfile_func64.ztell64_file)) (pfilefunc->zfile_func64.opaque,filestream);
+        return (*(pfilefunc->zfile_func64.ztell64_file)) (filestream);
     else
     {
-        uLong tell_uLong = (*(pfilefunc->ztell32_file))(pfilefunc->zfile_func64.opaque,filestream);
+        uLong tell_uLong = (*(pfilefunc->ztell32_file))(filestream);
         if ((tell_uLong) == ((uLong)-1))
             return (ZPOS64_T)-1;
         else
@@ -72,15 +72,15 @@ void fill_zlib_filefunc64_32_def_from_filefunc32(zlib_filefunc64_32_def* p_filef
 
 
 
-static voidpf  ZCALLBACK fopen_file_func OF((voidpf opaque, const char* filename, int mode));
-static uLong   ZCALLBACK fread_file_func OF((voidpf opaque, voidpf stream, void* buf, uLong size));
-static uLong   ZCALLBACK fwrite_file_func OF((voidpf opaque, voidpf stream, const void* buf,uLong size));
-static ZPOS64_T ZCALLBACK ftell64_file_func OF((voidpf opaque, voidpf stream));
-static long    ZCALLBACK fseek64_file_func OF((voidpf opaque, voidpf stream, ZPOS64_T offset, int origin));
-static int     ZCALLBACK fclose_file_func OF((voidpf opaque, voidpf stream));
-static int     ZCALLBACK ferror_file_func OF((voidpf opaque, voidpf stream));
+static voidpf  ZCALLBACK fopen_file_func OF((const char* filename, int mode));
+static uLong   ZCALLBACK fread_file_func OF((voidpf stream, void* buf, uLong size));
+static uLong   ZCALLBACK fwrite_file_func OF((voidpf stream, const void* buf,uLong size));
+static ZPOS64_T ZCALLBACK ftell64_file_func OF((voidpf stream));
+static long    ZCALLBACK fseek64_file_func OF((voidpf stream, ZPOS64_T offset, int origin));
+static int     ZCALLBACK fclose_file_func OF((voidpf stream));
+static int     ZCALLBACK ferror_file_func OF((voidpf stream));
 
-static voidpf ZCALLBACK fopen_file_func (voidpf opaque, const char* filename, int mode)
+static voidpf ZCALLBACK fopen_file_func (const char* filename, int mode)
 {
     FILE* file = NULL;
     const char* mode_fopen = NULL;
@@ -98,7 +98,7 @@ static voidpf ZCALLBACK fopen_file_func (voidpf opaque, const char* filename, in
     return file;
 }
 
-static voidpf ZCALLBACK fopen64_file_func (voidpf opaque, const void* filename, int mode)
+static voidpf ZCALLBACK fopen64_file_func (const void* filename, int mode)
 {
     FILE* file = NULL;
     const char* mode_fopen = NULL;
@@ -117,21 +117,21 @@ static voidpf ZCALLBACK fopen64_file_func (voidpf opaque, const void* filename, 
 }
 
 
-static uLong ZCALLBACK fread_file_func (voidpf opaque, voidpf stream, void* buf, uLong size)
+static uLong ZCALLBACK fread_file_func (voidpf stream, void* buf, uLong size)
 {
     uLong ret;
     ret = (uLong)fread(buf, 1, (size_t)size, (FILE *)stream);
     return ret;
 }
 
-static uLong ZCALLBACK fwrite_file_func (voidpf opaque, voidpf stream, const void* buf, uLong size)
+static uLong ZCALLBACK fwrite_file_func (voidpf stream, const void* buf, uLong size)
 {
     uLong ret;
     ret = (uLong)fwrite(buf, 1, (size_t)size, (FILE *)stream);
     return ret;
 }
 
-static long ZCALLBACK ftell_file_func (voidpf opaque, voidpf stream)
+static long ZCALLBACK ftell_file_func (voidpf stream)
 {
     long ret;
     ret = ftell((FILE *)stream);
@@ -139,14 +139,14 @@ static long ZCALLBACK ftell_file_func (voidpf opaque, voidpf stream)
 }
 
 
-static ZPOS64_T ZCALLBACK ftell64_file_func (voidpf opaque, voidpf stream)
+static ZPOS64_T ZCALLBACK ftell64_file_func (voidpf stream)
 {
     ZPOS64_T ret;
     ret = ftello((FILE *)stream);
     return ret;
 }
 
-static long ZCALLBACK fseek_file_func (voidpf  opaque, voidpf stream, uLong offset, int origin)
+static long ZCALLBACK fseek_file_func (voidpf stream, uLong offset, int origin)
 {
     int fseek_origin=0;
     long ret;
@@ -169,7 +169,7 @@ static long ZCALLBACK fseek_file_func (voidpf  opaque, voidpf stream, uLong offs
     return ret;
 }
 
-static long ZCALLBACK fseek64_file_func (voidpf  opaque, voidpf stream, ZPOS64_T offset, int origin)
+static long ZCALLBACK fseek64_file_func (voidpf stream, ZPOS64_T offset, int origin)
 {
     int fseek_origin=0;
     long ret;
@@ -195,14 +195,14 @@ static long ZCALLBACK fseek64_file_func (voidpf  opaque, voidpf stream, ZPOS64_T
 }
 
 
-static int ZCALLBACK fclose_file_func (voidpf opaque, voidpf stream)
+static int ZCALLBACK fclose_file_func (voidpf stream)
 {
     int ret;
     ret = fclose((FILE *)stream);
     return ret;
 }
 
-static int ZCALLBACK ferror_file_func (voidpf opaque, voidpf stream)
+static int ZCALLBACK ferror_file_func (voidpf stream)
 {
     int ret;
     ret = ferror((FILE *)stream);

--- a/minizip/ioapi.h
+++ b/minizip/ioapi.h
@@ -124,14 +124,14 @@ extern "C" {
 
 
 
-typedef voidpf   (ZCALLBACK *open_file_func)      OF((voidpf opaque, const char* filename, int mode));
-typedef uLong    (ZCALLBACK *read_file_func)      OF((voidpf opaque, voidpf stream, void* buf, uLong size));
-typedef uLong    (ZCALLBACK *write_file_func)     OF((voidpf opaque, voidpf stream, const void* buf, uLong size));
-typedef int      (ZCALLBACK *close_file_func)     OF((voidpf opaque, voidpf stream));
-typedef int      (ZCALLBACK *testerror_file_func) OF((voidpf opaque, voidpf stream));
+typedef voidpf   (ZCALLBACK *open_file_func)      OF((const char* filename, int mode));
+typedef uLong    (ZCALLBACK *read_file_func)      OF((voidpf stream, void* buf, uLong size));
+typedef uLong    (ZCALLBACK *write_file_func)     OF((voidpf stream, const void* buf, uLong size));
+typedef int      (ZCALLBACK *close_file_func)     OF((voidpf stream));
+typedef int      (ZCALLBACK *testerror_file_func) OF((voidpf stream));
 
-typedef long     (ZCALLBACK *tell_file_func)      OF((voidpf opaque, voidpf stream));
-typedef long     (ZCALLBACK *seek_file_func)      OF((voidpf opaque, voidpf stream, uLong offset, int origin));
+typedef long     (ZCALLBACK *tell_file_func)      OF((voidpf stream));
+typedef long     (ZCALLBACK *seek_file_func)      OF((voidpf stream, uLong offset, int origin));
 
 
 /* here is the "old" 32 bits structure structure */
@@ -147,9 +147,9 @@ typedef struct zlib_filefunc_def_s
     voidpf              opaque;
 } zlib_filefunc_def;
 
-typedef ZPOS64_T (ZCALLBACK *tell64_file_func)    OF((voidpf opaque, voidpf stream));
-typedef long     (ZCALLBACK *seek64_file_func)    OF((voidpf opaque, voidpf stream, ZPOS64_T offset, int origin));
-typedef voidpf   (ZCALLBACK *open64_file_func)    OF((voidpf opaque, const void* filename, int mode));
+typedef ZPOS64_T (ZCALLBACK *tell64_file_func)    OF((voidpf stream));
+typedef long     (ZCALLBACK *seek64_file_func)    OF((voidpf stream, ZPOS64_T offset, int origin));
+typedef voidpf   (ZCALLBACK *open64_file_func)    OF((const void* filename, int mode));
 
 typedef struct zlib_filefunc64_def_s
 {
@@ -176,12 +176,12 @@ typedef struct zlib_filefunc64_32_def_s
 } zlib_filefunc64_32_def;
 
 
-#define ZREAD64(filefunc,filestream,buf,size)     ((*((filefunc).zfile_func64.zread_file))   ((filefunc).zfile_func64.opaque,filestream,buf,size))
-#define ZWRITE64(filefunc,filestream,buf,size)    ((*((filefunc).zfile_func64.zwrite_file))  ((filefunc).zfile_func64.opaque,filestream,buf,size))
-//#define ZTELL64(filefunc,filestream)            ((*((filefunc).ztell64_file)) ((filefunc).opaque,filestream))
-//#define ZSEEK64(filefunc,filestream,pos,mode)   ((*((filefunc).zseek64_file)) ((filefunc).opaque,filestream,pos,mode))
-#define ZCLOSE64(filefunc,filestream)             ((*((filefunc).zfile_func64.zclose_file))  ((filefunc).zfile_func64.opaque,filestream))
-#define ZERROR64(filefunc,filestream)             ((*((filefunc).zfile_func64.zerror_file))  ((filefunc).zfile_func64.opaque,filestream))
+#define ZREAD64(filefunc,filestream,buf,size)     ((*((filefunc).zfile_func64.zread_file))   (filestream,buf,size))
+#define ZWRITE64(filefunc,filestream,buf,size)    ((*((filefunc).zfile_func64.zwrite_file))  (filestream,buf,size))
+//#define ZTELL64(filefunc,filestream)            ((*((filefunc).ztell64_file)) (filestream))
+//#define ZSEEK64(filefunc,filestream,pos,mode)   ((*((filefunc).zseek64_file)) (filestream,pos,mode))
+#define ZCLOSE64(filefunc,filestream)             ((*((filefunc).zfile_func64.zclose_file))  (filestream))
+#define ZERROR64(filefunc,filestream)             ((*((filefunc).zfile_func64.zerror_file))  (filestream))
 
 voidpf call_zopen64 OF((const zlib_filefunc64_32_def* pfilefunc,const void*filename,int mode));
 long    call_zseek64 OF((const zlib_filefunc64_32_def* pfilefunc,voidpf filestream, ZPOS64_T offset, int origin));

--- a/minizip/unzip.c
+++ b/minizip/unzip.c
@@ -1095,19 +1095,19 @@ local int unz64local_GetCurrentFileInfoInternal (unzFile file,
 
         if (lSeek!=0)
         {
-            if (ZSEEK64(s->z_filefunc, s->filestream,lSeek,ZLIB_FILEFUNC_SEEK_CUR)==0)
-                lSeek=0;
-            else
+            if (ZSEEK64(s->z_filefunc, s->filestream,lSeek,ZLIB_FILEFUNC_SEEK_CUR)!=0)
+            //    lSeek=0;
+            //else
                 err=UNZ_ERRNO;
         }
 
         if ((file_info.size_file_comment>0) && (commentBufferSize>0))
             if (ZREAD64(s->z_filefunc, s->filestream,szComment,uSizeRead)!=uSizeRead)
                 err=UNZ_ERRNO;
-        lSeek+=file_info.size_file_comment - uSizeRead;
+        //lSeek+=file_info.size_file_comment - uSizeRead;
     }
-    else
-        lSeek+=file_info.size_file_comment;
+    //else
+    //    lSeek+=file_info.size_file_comment;
 
 
     if ((err==UNZ_OK) && (pfile_info!=NULL))
@@ -1534,13 +1534,13 @@ extern int ZEXPORT unzOpenCurrentFile3 (unzFile file, int* method,
         }
     }
 
-    if ((s->cur_file_info.compression_method!=0) &&
+    //if ((s->cur_file_info.compression_method!=0) &&
 /* #ifdef HAVE_BZIP2 */
-        (s->cur_file_info.compression_method!=Z_BZIP2ED) &&
+    //    (s->cur_file_info.compression_method!=Z_BZIP2ED) &&
 /* #endif */
-        (s->cur_file_info.compression_method!=Z_DEFLATED))
+    //    (s->cur_file_info.compression_method!=Z_DEFLATED))
 
-        err=UNZ_BADZIPFILE;
+    //    err=UNZ_BADZIPFILE;
 
     pfile_in_zip_read_info->crc32_wait=s->cur_file_info.crc;
     pfile_in_zip_read_info->crc32=0;

--- a/minizip/zip.c
+++ b/minizip/zip.c
@@ -1035,10 +1035,12 @@ int Write_LocalFileHeader(zip64_internal* zi, const char* filename, uInt size_ex
       zi->ci.pos_zip64extrainfo = ZTELL64(zi->z_filefunc,zi->filestream);
 
       err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (short)HeaderID,2);
-      err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (short)DataSize,2);
-
-      err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (ZPOS64_T)UncompressedSize,8);
-      err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (ZPOS64_T)CompressedSize,8);
+      if (err==ZIP_OK)
+          err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (short)DataSize,2);
+      if (err==ZIP_OK)
+          err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (ZPOS64_T)UncompressedSize,8);
+      if (err==ZIP_OK)
+          err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (ZPOS64_T)CompressedSize,8);
   }
 
   return err;
@@ -1533,13 +1535,14 @@ extern int ZEXPORT zipCloseFileInZipRaw64 (zipFile file, ZPOS64_T uncompressed_s
                                 uLong uTotalOutBefore;
                                 if (zi->ci.stream.avail_out == 0)
                                 {
-                                        if (zip64FlushWriteBuffer(zi) == ZIP_ERRNO)
-                                                err = ZIP_ERRNO;
+                                        //if (zip64FlushWriteBuffer(zi) == ZIP_ERRNO)
+                                        //        err = ZIP_ERRNO;
+                                    zip64FlushWriteBuffer(zi);
                                         zi->ci.stream.avail_out = (uInt)Z_BUFSIZE;
                                         zi->ci.stream.next_out = zi->ci.buffered_data;
                                 }
                                 uTotalOutBefore = zi->ci.stream.total_out;
-                                err=deflate(&zi->ci.stream,  Z_FINISH);
+                            err=deflate(&zi->ci.stream,  Z_FINISH);
                                 zi->ci.pos_in_buffered_data += (uInt)(zi->ci.stream.total_out - uTotalOutBefore) ;
                         }
                 }
@@ -1679,7 +1682,7 @@ extern int ZEXPORT zipCloseFileInZipRaw64 (zipFile file, ZPOS64_T uncompressed_s
       if(zi->ci.pos_local_header >= 0xffffffff)
       {
         zip64local_putValue_inmemory(p, zi->ci.pos_local_header, 8);
-        p += 8;
+        //p += 8;
       }
 
       // Update how much extra free space we got in the memory buffer


### PR DESCRIPTION
Fixing warnings generated by Xcode 6.3.1, mostly unused parameters or vars.

The only behavior changes are:
- switching from rand() to arc4random_uniform()
- when there is an error, will stop calling zip64local_putValue()
