### PR TITLE
update the file modification date is a little time-consuming

### DIFF
--- a/ZipArchive.h
+++ b/ZipArchive.h
@@ -92,6 +92,9 @@ typedef void(^ZipArchiveProgressUpdateBlock)(int percentage, int filesProcessed,
 
 @property (nonatomic, assign) ZipArchiveCompression compression;
 
+/** Do you need to update the file modification time? This operation is a little time-consuming.*/
+@property (nonatomic, assign) BOOL needUpdateFileModificationDate;
+
 /**
     @brief      String encoding to be used when interpreting file names in the zip file.
 */

--- a/ZipArchive.m
+++ b/ZipArchive.m
@@ -51,6 +51,7 @@
         _fileManager = fileManager;
         self.stringEncoding = NSUTF8StringEncoding;
         self.compression = ZipArchiveCompressionDefault;
+        self.needUpdateFileModificationDate = YES;
 	}
 	return self;
 }
@@ -385,7 +386,7 @@
                 [(NSMutableArray*)_unzippedFiles addObject:fullPath];
                 
                 // set the orignal datetime property
-                if( fileInfo.tmu_date.tm_year!=0 )
+                if(self.needUpdateFileModificationDate && fileInfo.tmu_date.tm_year!=0 )
                 {
                     NSDateComponents* components = [[NSDateComponents alloc] init];
                     components.second = fileInfo.tmu_date.tm_sec;


### PR DESCRIPTION
Thank for giving us a a nice project for zip and unzip.
But when I unziped a lot of documents, the efficiency will slow down. I use instrument's time profile to see that updating the file modification date cost 38.8% of  method `UnzipFileTo:overWrite:`. 
I think most of us don't care about the file's modification date, so this operation should be deleted or have a choice?
Thanks.
