### PR TITLE
Lets use NSCalendarIdentifierGregorian constant

### DIFF
--- a/ZipArchive.m
+++ b/ZipArchive.m
@@ -125,7 +125,7 @@
         fileDate = [NSDate date];
 
     
-    NSCalendar *gregorianCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
+    NSCalendar *gregorianCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     NSDateComponents* components = [gregorianCalendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay |
                                     NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond fromDate:fileDate];
     [gregorianCalendar release];
@@ -370,7 +370,7 @@
                     components.month = fileInfo.tmu_date.tm_mon;
                     components.year = fileInfo.tmu_date.tm_year;
                     
-                    NSCalendar *gregorianCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
+                    NSCalendar *gregorianCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
                     NSDate* orgDate = [[gregorianCalendar dateFromComponents:components] retain];
                     [components release];
                     [gregorianCalendar release];
@@ -527,7 +527,7 @@
 	[comps setMonth:1];
 	[comps setYear:1980];
 	NSCalendar *gregorian = [[NSCalendar alloc]
-							 initWithCalendarIdentifier:NSGregorianCalendar];
+							 initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
 	NSDate *date = [gregorian dateFromComponents:comps];
 	
 	[comps release];


### PR DESCRIPTION
NSCalendarIdentifierGregorian constant is available since iOS 4.0 NSGregorianCalendar constant is  depricated since iOS 8.0
