### PR TITLE
Fixing the date correction introduced in commit 2201e963dadfa6dc2af4e…

### DIFF
--- a/ZipArchive.m
+++ b/ZipArchive.m
@@ -392,7 +392,7 @@
                     components.minute = fileInfo.tmu_date.tm_min;
                     components.hour = fileInfo.tmu_date.tm_hour;
                     components.day = fileInfo.tmu_date.tm_mday;
-                    components.month = fileInfo.tmu_date.tm_mon + 1;
+                    components.month = fileInfo.tmu_date.tm_mon;
                     components.year = fileInfo.tmu_date.tm_year;
                     
                     NSCalendar *gregorianCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];


### PR DESCRIPTION
…9c98617edb6a4df780e. When using the zipping facilities of ZipArchive it is using the Gregorian calendar to determine the date as of commit 3588d02649825f0c55be3d64fead9278fa79bfb6.