### PR TITLE
fix the zipperdown security problem

### DIFF
--- a/ZipArchive.m
+++ b/ZipArchive.m
@@ -337,6 +337,23 @@
             {// contains a path
                 strPath = [strPath stringByReplacingOccurrencesOfString:@"\\" withString:@"/"];
             }
+            
+            // fix zipper down
+            if ([strPath rangeOfString:@".."].length > 0)
+            {
+                // 忽略
+                ret = unzCloseCurrentFile( _unzFile );
+                if (ret != UNZ_OK) {
+                    [self OutputErrorMessage:@"file with '..' was ignored but failed to be closed"];
+                    success = NO;
+                    break;
+                }
+                
+                ret = unzGoToNextFile( _unzFile );
+                index ++;
+                continue;
+            }
+            
             NSString* fullPath = [path stringByAppendingPathComponent:strPath];
             
             if( isDirectory )

--- a/ZipArchive.podspec
+++ b/ZipArchive.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ZipArchive"
-  s.version      = "1.4.0"
+  s.version      = "1.4.1"
   s.summary      = "An Objective C class for zip/unzip on iPhone and Mac OS X."
   s.description  = <<-DESC
 ZipArchive is an Objective-C class to compress or uncompress zip files, which is base on open source code "MiniZip".
@@ -10,7 +10,7 @@ It can be used for iPhone application development, and cocoa on Mac OSX as well.
   s.homepage     = "https://github.com/mattconnolly/ZipArchive"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { "Unknown Name" => "acsolu@gmail.com", "Matt Connolly" => "matt.connolly@me.com" }
-  s.source       = { :git => 'https://github.com/mattconnolly/ZipArchive.git', :tag => '1.4.0' }
+  s.source       = { :git => 'https://github.com/mattconnolly/ZipArchive.git', :tag => '1.4.1' }
   s.source_files = '*.{h,m}', 'minizip/crypt.{h,c}', 'minizip/ioapi.{h,c}', 'minizip/mztools.{h,c}', 'minizip/unzip.{h,c}', 'minizip/zip.{h,c}'
   s.public_header_files = '*.h'
   s.library   = 'z'


### PR DESCRIPTION
since zipperdown found the security problem, we need check the file path string to skip specified string to avoid security risk. 