### PR TITLE
Fix Xcode 9 warnings (still ok in Xcode 10)

### DIFF
--- a/ZipArchive.h
+++ b/ZipArchive.h
@@ -39,7 +39,6 @@ typedef void(^ZipArchiveProgressUpdateBlock)(int percentage, int filesProcessed,
     ZipArchive calls this selector on the delegate when errors are encountered.
     
     @param      msg     a string describing the error.
-    @result     void
 */
 
 -(void) ErrorMessage:(NSString*) msg;

--- a/minizip/mztools.c
+++ b/minizip/mztools.c
@@ -27,13 +27,7 @@
   WRITE_16((unsigned char*)(buff) + 2, (n) >> 16); \
 } while(0)
 
-extern int ZEXPORT unzRepair(file, fileOut, fileOutTmp, nRecovered, bytesRecovered)
-const char* file;
-const char* fileOut;
-const char* fileOutTmp;
-uLong* nRecovered;
-uLong* bytesRecovered;
-{
+extern int ZEXPORT unzRepair(const char* file, const char* fileOut, const char* fileOutTmp, uLong* nRecovered, uLong* bytesRecovered) {
   int err = Z_OK;
   FILE* fpZip = fopen(file, "rb");
   FILE* fpOut = fopen(fileOut, "wb");

--- a/minizip/unzip.c
+++ b/minizip/unzip.c
@@ -1167,7 +1167,7 @@ extern int ZEXPORT unzGetCurrentFileInfo (unzFile file,
         pfile_info->internal_fa = file_info64.internal_fa;
         pfile_info->external_fa = file_info64.external_fa;
 
-        pfile_info->tmu_date = file_info64.tmu_date,
+        pfile_info->tmu_date = file_info64.tmu_date;
 
 
         pfile_info->compressed_size = (uLong)file_info64.compressed_size;


### PR DESCRIPTION
# 🖖