### PR TITLE
fix _progressBlock not released before [super dealloc]

### DIFF
--- a/ZipArchive.m
+++ b/ZipArchive.m
@@ -65,6 +65,7 @@
     [_password release];
     [_delegate release];
     [_unzippedFiles release];
+    [_progressBlock release];
     
 	[super dealloc];
 }


### PR DESCRIPTION
when you run Xcode analyze,Xcode will tell you 

> The '_progressBlock' ivar in 'ZipArchive' was copied by a synthesized property but not released before '[super dealloc]'

and this commit will fix it